### PR TITLE
LDT-121: API Endpoint for Exporting Site Configurations.

### DIFF
--- a/config/sync/config_expose.settings.yml
+++ b/config/sync/config_expose.settings.yml
@@ -1,0 +1,3 @@
+selected_configs:
+  - admin_toolbar.settings
+  - admin_toolbar_tools.settings

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -12,6 +12,7 @@ module:
   ckeditor5: 0
   comment: 0
   config: 0
+  config_expose: 0
   contact: 0
   contextual: 0
   datetime: 0

--- a/config/sync/rest.resource.config_get.yml
+++ b/config/sync/rest.resource.config_get.yml
@@ -1,0 +1,18 @@
+uuid: 3981b9f4-a916-427c-b009-0545b49eeb90
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_expose
+    - serialization
+    - user
+id: config_get
+plugin_id: config_get
+granularity: resource
+configuration:
+  methods:
+    - GET
+  formats:
+    - json
+  authentication:
+    - cookie

--- a/config/sync/rest.resource.config_list.yml
+++ b/config/sync/rest.resource.config_list.yml
@@ -1,0 +1,18 @@
+uuid: 7efcbdb9-bb12-44cb-821c-c60d1182f88d
+langcode: en
+status: true
+dependencies:
+  module:
+    - config_expose
+    - serialization
+    - user
+id: config_list
+plugin_id: config_list
+granularity: resource
+configuration:
+  methods:
+    - GET
+  formats:
+    - json
+  authentication:
+    - cookie

--- a/web/modules/custom/config_expose/config_expose.info.yml
+++ b/web/modules/custom/config_expose/config_expose.info.yml
@@ -1,0 +1,5 @@
+name: Config Expose
+description: Provides custom API endpoint to expose site configs.
+package: Custom
+type: module
+core_version_requirement: ^10

--- a/web/modules/custom/config_expose/config_expose.routing.yml
+++ b/web/modules/custom/config_expose/config_expose.routing.yml
@@ -1,0 +1,7 @@
+config_expose.settings:
+  path: '/admin/config/system/config-expose'
+  defaults:
+    _form: '\Drupal\config_expose\Form\ConfigExposeForm'
+    _title: 'Config Expose Form'
+  requirements:
+    _permission: 'administer site configuration'

--- a/web/modules/custom/config_expose/src/Form/ConfigExposeForm.php
+++ b/web/modules/custom/config_expose/src/Form/ConfigExposeForm.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\config_expose\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Config\StorageInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class ConfigExposeForm extends ConfigFormBase {
+
+  /**
+   * The config storage.
+   *
+   * @var \Drupal\Core\Config\StorageInterface
+   */
+  protected $configStorage;
+
+  /**
+   * Tracks the valid config entity type definitions.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeInterface[]
+   */
+  protected $definitions = [];
+
+  /**
+   * Constructs a new ConfigExposeSettingsForm.
+   *
+   * @param \Drupal\Core\Config\StorageInterface $config_storage
+   *   The config storage.
+   */
+  public function __construct(StorageInterface $config_storage) {
+    $this->configStorage = $config_storage;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.storage')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'config_expose_admin_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'config_expose.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $configs = $this->getConfigsList();
+    $selected = $this->config('config_expose.settings')->get('selected_configs') ?: [];
+    $form['configurations'] = [
+      '#type' => 'checkboxes',
+      '#title' => $this->t('Select configurations to be exposed'),
+      '#options' => $configs,
+      '#default_value' => $selected,
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * Returns a list of configurations.
+   *
+   * @return array
+   *   A list of available configurations.
+   */
+  private function getConfigsList() {
+    $config_name = $this->configStorage->listAll();
+    $config_list = array_combine($config_name, $config_name);
+    return $config_list;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $selected_configs = array_values(array_filter($form_state->getValue('configurations')));
+    $this->config('config_expose.settings')
+      ->set('selected_configs', $selected_configs)
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+}

--- a/web/modules/custom/config_expose/src/Plugin/rest/resource/GetConfigListResource.php
+++ b/web/modules/custom/config_expose/src/Plugin/rest/resource/GetConfigListResource.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\config_expose\Plugin\rest\resource;
+
+use Drupal\rest\Plugin\ResourceBase;
+use Drupal\rest\ResourceResponse;
+use Psr\Log\LoggerInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * Provides a custom endpoint to fetch a list of allowed configs.
+ * @RestResource(
+ *   id = "config_list",
+ *   label = @Translation("List of allowed configs"),
+ *   uri_paths = {
+ *     "canonical" = "/api/config-list"
+ *   }
+ * )
+ */
+class GetConfigListResource extends ResourceBase {
+  /**
+   * The configuration factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a GetConfigResource instance.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param array $serializer_formats
+   *   The available serialization formats.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   A logger instance.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The configuration factory.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, $serializer_formats, LoggerInterface $logger, ConfigFactoryInterface $config_factory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger);
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->getParameter('serializer.formats'),
+      $container->get('logger.factory')->get('rest'),
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * Responds to GET requests.
+   *
+   * Returns the list of allowed configurations.
+   *
+   * @return \Drupal\rest\ResourceResponse
+   *   The response containing the list of allowed configurations.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
+   *   When admin has not selected any configs that can be exposed.
+   */
+  public function get() {
+    $allowed_configs = $this->configFactory->get('config_expose.settings')
+      ->get('selected_configs') ?? [];
+
+    // When admin has not selected any configs that can be exposed.
+    if (empty($allowed_configs)) {
+      throw new BadRequestHttpException('Admin has not allowed any configs to be exposed.');
+    }
+    else {
+      $response = new ResourceResponse($allowed_configs);
+      $response->getCacheableMetadata()->addCacheTags(['config:config_expose.settings']);
+      return $response;
+    }
+  }
+}

--- a/web/modules/custom/config_expose/src/Plugin/rest/resource/GetConfigResource.php
+++ b/web/modules/custom/config_expose/src/Plugin/rest/resource/GetConfigResource.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\config_expose\Plugin\rest\resource;
+
+use Drupal\rest\Plugin\ResourceBase;
+use Drupal\rest\ResourceResponse;
+use Psr\Log\LoggerInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * Provides a custom endpoint which can be used to expose any config.
+ * @RestResource(
+ *   id = "config_get",
+ *   label = @Translation("Custom resource to get details of a particular config"),
+ *   uri_paths = {
+ *     "canonical" = "/api/config-get/{conf_name}"
+ *   }
+ * )
+ */
+class GetConfigResource extends ResourceBase {
+  /**
+   * The configuration factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a GetConfigResource instance.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param array $serializer_formats
+   *   The available serialization formats.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   A logger instance.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The configuration factory.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, $serializer_formats, LoggerInterface $logger, ConfigFactoryInterface $config_factory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger);
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->getParameter('serializer.formats'),
+      $container->get('logger.factory')->get('rest'),
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * Responds to GET requests.
+   *
+   * Returns details for the specified configuration.
+   *
+   * @param string $conf_name
+   *   The name of the configuration.
+   *
+   * @return \Drupal\rest\ResourceResponse
+   *   The response containing the configuration detail.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+   *   When specified configuration is not allowed to be exposed by admin.
+   */
+  public function get($conf_name = NULL) {
+    $config = $this->configFactory->get('config_expose.settings')
+    ->get('selected_configs') ?? [];
+    // When specified configuration is not allowed to be exposed by admin.
+    if (!in_array($conf_name, $config)) {
+      throw new BadRequestHttpException($this->t('The configuration (@config_name) is not yet exposed by admin.', ['@config_name' => $conf_name]));
+    }
+
+    $data[$conf_name] = $this->configFactory->get($conf_name)->getRawData();
+    $response = new ResourceResponse($data);
+    $response->getCacheableMetadata()->addCacheTags(['config:config_expose.settings']);
+    return $response;
+  }
+}


### PR DESCRIPTION
When no configs are allowed to be exposed by admin:
<img width="1085" alt="Screenshot 2024-05-16 at 11 22 15 AM" src="https://github.com/KuldeepBarot/headless-lab/assets/14309984/16fc3e01-49c0-4b6e-8622-d269cf851d5f">
List of configs allowed to be exposed by admin:
<img width="1066" alt="Screenshot 2024-05-16 at 11 24 16 AM" src="https://github.com/KuldeepBarot/headless-lab/assets/14309984/71e0108b-441c-4020-b81e-36b8345bca38">
When a requested config is not yet exposed by admin:
<img width="1088" alt="Screenshot 2024-05-16 at 11 27 52 AM" src="https://github.com/KuldeepBarot/headless-lab/assets/14309984/56522319-c3e3-4c84-82a7-2258204c1ae1">
When a requested config is exposed by admin:
<img width="1086" alt="Screenshot 2024-05-16 at 11 29 28 AM" src="https://github.com/KuldeepBarot/headless-lab/assets/14309984/e3482dc1-5f14-4ccb-b010-b48869f3ef4b">